### PR TITLE
Add toAsset property to config object in AssetValueLogger

### DIFF
--- a/src/config.ts.dist
+++ b/src/config.ts.dist
@@ -23,7 +23,7 @@ export default {
 
     plugins: [/*
         new ProfitCalculator(),
-        new AssetValueLogger("USD"),
+        new AssetValueLogger({ toAsset: "USD" }),
         new OrderLogger(),
         new SpreadLogger(),
     */],


### PR DESCRIPTION
Fixes an issue with the initialization of `AssetValueLogger()` in the plugins section of `config.ts.dist` default values file

- `AssetValueLogger` was expecting a config object with the property `toAsset: string` but it was only passing `'USD'`